### PR TITLE
Include local hostname in dev cert DNS names.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ on:
       - release-*
 env:
   PRE_RELEASE: ${{ github.ref == 'refs/heads/main' && 'development' || '' }}
-  GO_VERSION: "1.17"
+  GO_VERSION: "1.20"
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    steps:           
+    steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install Tools
-        run: |         
+        run: |
           go run mage.go deps
       - name: Lint
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,17 +4,42 @@
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by zerolog
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by zerolog"
+    # Rules to apply.
+    #
+    # Variables:
+    # - File Variables
+    #   you can still use and exclamation mark ! in front of a variable to say not to use it.
+    #   Example !$test will match any file that is not a go test file.
+    #
+    #   `$all` - matches all go files
+    #   `$test` - matches all go test files
+    #
+    # - Package Variables
+    #
+    #  `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+    #
+    # Default: Only allow $gostd in all files.
+    rules:
+      # Name of a rule.
+      main:
+        # List of file globs that will match this list of settings to compare against.
+        files:
+          - $all
+        # List of allowed packages.
+        allow:
+          - $gostd
+          - github.com/aserto-dev
+        # Packages that are not allowed where the value is a suggestion.
+        deny:
+          - pkg: "github.com/sirupsen/logrus"
+            desc: not allowed
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
   dupl:
     threshold: 100
   funlen:
     lines: 100
-    statements: 50
+    statements: 80
   gci:
     local-prefixes: github.com/golangci/golangci-lint
   goconst:
@@ -31,9 +56,10 @@ linters-settings:
       - dupImport # https://github.com/go-critic/go-critic/issues/845
       - ifElseChain
       - octalLiteral
+      - whyNoLint
       - wrapperFunc
   gocyclo:
-    min-complexity: 20
+    min-complexity: 18
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   golint:
@@ -42,7 +68,11 @@ linters-settings:
     settings:
       mnd:
         # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+        checks:
+          - argument
+          - case
+          - condition
+          - return
   govet:
     check-shadowing: true
     settings:
@@ -57,7 +87,6 @@ linters-settings:
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -67,33 +96,52 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
+    - asciicheck
     - bodyclose
-    - deadcode
-    - depguard
+    # - depguard
+    - dogsled
     - errcheck
     - exportloopref
+    - exhaustive
     - funlen
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
+    - godot
+    - goerr113
     - gofmt
     - goimports
+    - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
-    - revive
+    - noctx
+    - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
+    - testpackage
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+
+  # don't enable:
+    # - dupl
+    # - gochecknoglobals
+    # - gocognit
+    # - godox
+    # - gomnd
+    # - lll
+    # - nestif
+    # - nolintlint # conflict with 1.19 gofmt changes
+    # - prealloc
+    # - revive
+    # - wsl
+    # - whitespace
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.
@@ -114,7 +162,7 @@ issues:
       - gocritic
     - text: "unnamedResult:"
       linters:
-      - gocritic      
-
-run:
-  timeout: 5m
+      - gocritic
+    - text: "G404"
+      linters:
+      - gosec

--- a/Depfile
+++ b/Depfile
@@ -2,7 +2,7 @@
 go:
   gotestsum:
     importPath: "gotest.tools/gotestsum"
-    version: "v1.6.2"
+    version: "v1.10.0"
   golangci-lint:
     importPath: "github.com/golangci/golangci-lint/cmd/golangci-lint"
-    version: "v1.43.0"
+    version: "v1.53.2"

--- a/certs.go
+++ b/certs.go
@@ -17,12 +17,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Generator generates certs without any external dependencies
+// Generator generates certs without any external dependencies.
 type Generator struct {
 	logger *zerolog.Logger
 }
 
-// CertGenConfig contains details about how cert generation should happen
+// CertGenConfig contains details about how cert generation should happen.
 type CertGenConfig struct {
 	CommonName       string
 	CertKeyPath      string
@@ -31,7 +31,7 @@ type CertGenConfig struct {
 	DefaultTLSGenDir string
 }
 
-// NewGenerator creates a new cert generator
+// NewGenerator creates a new cert generator.
 func NewGenerator(logger *zerolog.Logger) *Generator {
 	log := logger.With().Str("component", "cert-generator").Logger()
 	return &Generator{

--- a/certs.go
+++ b/certs.go
@@ -102,7 +102,17 @@ func (c *Generator) MakeDevCert(genConfig *CertGenConfig) error {
 		return errors.Wrap(err, "failed to encode key")
 	}
 
-	c.logger.Info().Str("common-name", genConfig.CommonName).Msg("generating certificate and key")
+	dnsNames := []string{"localhost"}
+	hostname, err := os.Hostname()
+	if err == nil {
+		// If there's a hostname for the local machine, add it to the cert's DNS names.
+		dnsNames = append(dnsNames, hostname)
+	}
+
+	c.logger.Info().
+		Str("common-name", genConfig.CommonName).
+		Strs("dns-names", dnsNames).
+		Msg("generating certificate and key")
 
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(1658),
@@ -115,8 +125,8 @@ func (c *Generator) MakeDevCert(genConfig *CertGenConfig) error {
 			PostalCode:    []string{"-"},
 			CommonName:    genConfig.CommonName,
 		},
-		IPAddresses:  []net.IP{net.IPv4(0, 0, 0, 0), net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     dnsNames,
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().AddDate(1, 0, 0),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aserto-dev/certs
 
-go 1.17
+go 1.19
 
 require (
 	github.com/magefile/mage v1.13.0

--- a/tls.go
+++ b/tls.go
@@ -3,21 +3,20 @@ package certs
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 )
 
-// TLSCredsConfig contains paths to certificates
+// TLSCredsConfig contains paths to certificates.
 type TLSCredsConfig struct {
 	TLSCertPath   string `json:"tls_cert_path"`
 	TLSKeyPath    string `json:"tls_key_path"`
 	TLSCACertPath string `json:"tls_ca_cert_path"`
 }
 
-// GRPCServerTLSCreds gets TLS credentials for a GRPC server
+// GRPCServerTLSCreds gets TLS credentials for a GRPC server.
 func GRPCServerTLSCreds(config TLSCredsConfig) (credentials.TransportCredentials, error) {
 	certificate, err := tls.LoadX509KeyPair(config.TLSCertPath, config.TLSKeyPath)
 	if err != nil {
@@ -32,7 +31,7 @@ func GRPCServerTLSCreds(config TLSCredsConfig) (credentials.TransportCredentials
 	return credentials.NewTLS(tlsConfig), nil
 }
 
-// GatewayAsClientTLSCreds returns transport credentials so an HTTP gateway can connect to the GRPC server
+// GatewayAsClientTLSCreds returns transport credentials so an HTTP gateway can connect to the GRPC server.
 func GatewayAsClientTLSCreds(config TLSCredsConfig) (credentials.TransportCredentials, error) {
 
 	certPool := x509.NewCertPool()
@@ -48,7 +47,7 @@ func GatewayAsClientTLSCreds(config TLSCredsConfig) (credentials.TransportCreden
 
 	certificate, err := tls.LoadX509KeyPair(config.TLSCertPath, config.TLSKeyPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not load server key pair: %s", err)
+		return nil, errors.Wrap(err, "could not load server key pair")
 	}
 
 	clientCreds := credentials.NewTLS(&tls.Config{
@@ -60,7 +59,7 @@ func GatewayAsClientTLSCreds(config TLSCredsConfig) (credentials.TransportCreden
 	return clientCreds, nil
 }
 
-// GatewayServerTLSConfig returns a TLS config for the gateway server
+// GatewayServerTLSConfig returns a TLS config for the gateway server.
 func GatewayServerTLSConfig(config TLSCredsConfig) (*tls.Config, error) {
 	certificate, err := tls.LoadX509KeyPair(config.TLSCertPath, config.TLSKeyPath)
 	if err != nil {


### PR DESCRIPTION
This PR includes the machine's hostname, if available, as a DNS name in the generated certs in addition to `localhost`.
I was unable to get the console to successfully call a locally-run tenant service using `localhost` or `127.0.0.1`. The only setup that seemed to work is using my machine's hostname and this PR is needed make that scenario work.